### PR TITLE
[feat][common-jpa] 모듈 생성 & GitHub Packages 배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ public class Sample extends BaseEntity {
 }
 ```
 
-소프트 삭제가 필요한 경우 `delete()` 메서드를 호출합니다.
+소프트 삭제가 필요한 경우 도메인 엔티티에서 `delete()`를 호출하는 메서드를 정의합니다.
 
 ```java
-sample.delete();  // deletedAt 자동 설정
+// 도메인 엔티티
+public void softDelete() {
+    // 삭제 권한 검증
+    delete();  // deletedAt 자동 설정
+}
 ```
 
 ### BaseUserEntity
@@ -111,8 +115,12 @@ public class Sample extends BaseUserEntity {
 }
 ```
 
-소프트 삭제가 필요한 경우 `delete(UUID userId)` 메서드를 호출합니다.
+소프트 삭제가 필요한 경우 도메인 엔티티에서 `delete(UUID userId)`를 호출하는 메서드를 정의합니다.
 
 ```java
-sample.delete(userId);  // deletedAt, deletedBy 자동 설정
+// 도메인 엔티티
+public void softDelete(UUID userId) {
+    // 삭제 권한 검증
+    delete(userId);  // deletedAt, deletedBy 자동 설정
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,118 @@
-# com.firstticket.common-jpa
+# com.first-ticket.common-jpa
+
+JPA 기본 엔티티 및 설정을 제공하는 공통 모듈입니다.
+
+---
+
+## 📝 버전
+
+| 버전 | 변경 내용 |
+|------|-----------|
+| `0.0.1-SNAPSHOT` | • JPA 기본 엔티티 및 설정 추가 (`BaseEntity`, `BaseUserEntity`, `CommonJpaAutoConfiguration`)<br>• QueryDSL 설정 추가 (`JPAQueryFactory` 빈 등록) |
+
+---
+
+## 📦 의존성 추가
+
+> 배포 방법 및 의존성 추가는 [common README](https://github.com/first-ticket/common)를 참고해주세요.
+
+```groovy
+implementation 'com.first-ticket:common-jpa:0.0.1-SNAPSHOT'
+```
+
+---
+
+## 🗂️ 패키지 구조
+
+```
+com.firstticket.common.persistence
+├── CommonJpaAutoConfiguration.java  ← EntityScan, JPAQueryFactory 설정
+├── BaseEntity.java                  ← 생성/수정/삭제 시간
+└── BaseUserEntity.java              ← BaseEntity + 생성/수정/삭제 유저
+```
+
+---
+
+## 🗄️ CommonJpaAutoConfiguration
+
+`com.firstticket` 하위 패키지를 자동으로 스캔하여 JPA 엔티티와 Repository를 등록합니다.
+`JPAQueryFactory` 빈을 자동으로 등록하여 QueryDSL을 바로 사용할 수 있습니다.
+
+> ⚠️ 모든 서비스의 베이스 패키지가 `com.firstticket`으로 시작해야 합니다.
+
+```java
+// 서비스 엔티티 자동 스캔됨
+package com.firstticket.sampleservice.domain;
+
+@Entity
+public class Sample extends BaseEntity { ... }
+```
+
+QueryDSL 사용 시 `JPAQueryFactory`를 주입받아 바로 사용합니다.
+
+```java
+@Repository
+@RequiredArgsConstructor
+public class SampleQueryRepositoryImpl implements SampleQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Sample> findBySpec(SampleSearchSpec spec) {
+        return queryFactory
+            .selectFrom(sample)
+            .where(...)
+            .fetch();
+    }
+}
+```
+
+---
+
+## 🏗️ BaseEntity / BaseUserEntity
+
+### BaseEntity
+
+생성 시간, 수정 시간, 삭제 시간을 자동으로 관리합니다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `createdAt` | `LocalDateTime` | 생성 시간 (자동) |
+| `updatedAt` | `LocalDateTime` | 수정 시간 (자동, insert 시 null) |
+| `deletedAt` | `LocalDateTime` | 삭제 시간 |
+
+```java
+@Entity
+public class Sample extends BaseEntity {
+    // createdAt, updatedAt, deletedAt 자동 포함
+}
+```
+
+소프트 삭제가 필요한 경우 `delete()` 메서드를 호출합니다.
+
+```java
+sample.delete();  // deletedAt 자동 설정
+```
+
+### BaseUserEntity
+
+`BaseEntity`를 상속받아 생성/수정/삭제 유저 UUID를 추가로 관리합니다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `createdBy` | `UUID` | 생성 유저 (자동) |
+| `updatedBy` | `UUID` | 수정 유저 (자동, insert 시 null) |
+| `deletedBy` | `UUID` | 삭제 유저 |
+
+```java
+@Entity
+public class Sample extends BaseUserEntity {
+    // createdAt, updatedAt, deletedAt, createdBy, updatedBy, deletedBy 자동 포함
+}
+```
+
+소프트 삭제가 필요한 경우 `delete(UUID userId)` 메서드를 호출합니다.
+
+```java
+sample.delete(userId);  // deletedAt, deletedBy 자동 설정
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java'
+    id 'java-library'
+    id 'maven-publish'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -14,16 +15,67 @@ java {
     }
 }
 
+bootJar { enabled = false }
+jar {
+    enabled = true
+    archiveClassifier.set('')
+}
+
+def env = [:]
+def envFile = rootProject.file(".env")
+if (envFile.exists()) {
+    envFile.eachLine { line ->
+        if (line && !line.startsWith("#") && line.contains("=")) {
+            def (key, value) = line.split("=", 2)
+            env[key.trim()] = value.trim()
+        }
+    }
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            name = 'GitHubPackages'
+            url = 'https://maven.pkg.github.com/first-ticket/common-jpa'
+            credentials {
+                username = env['GITHUB_USER']
+                password = env['GITHUB_TOKEN']
+            }
+        }
+    }
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+    delete querydslDir
 }

--- a/src/main/java/com/firstticket/common/persistence/BaseEntity.java
+++ b/src/main/java/com/firstticket/common/persistence/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.firstticket.common.persistence;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", insertable = false)
+    protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    protected void delete() {
+        if (this.deletedAt != null) {
+            return;
+        }
+
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/firstticket/common/persistence/BaseUserEntity.java
+++ b/src/main/java/com/firstticket/common/persistence/BaseUserEntity.java
@@ -1,0 +1,40 @@
+package com.firstticket.common.persistence;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseUserEntity extends BaseEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", nullable = false, updatable = false)
+    protected UUID createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", insertable = false)
+    protected UUID updatedBy;
+
+    @Column(name = "deleted_by")
+    protected UUID deletedBy;
+
+    protected void delete(UUID deletedBy) {
+        if (this.deletedAt != null) {
+            return;
+        }
+
+        super.delete();
+        this.deletedBy = deletedBy;
+    }
+}

--- a/src/main/java/com/firstticket/common/persistence/CommonJpaAutoConfiguration.java
+++ b/src/main/java/com/firstticket/common/persistence/CommonJpaAutoConfiguration.java
@@ -1,0 +1,25 @@
+package com.firstticket.common.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@AutoConfiguration
+@EntityScan(basePackages = "com.firstticket")
+@EnableJpaRepositories(basePackages = "com.firstticket")
+@EnableJpaAuditing
+public class CommonJpaAutoConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.firstticket.common.persistence.CommonJpaAutoConfiguration


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- `common` 모듈에서 JPA 관련 코드를 분리하여 `common-jpa` 모듈 생성
- `BaseEntity`, `BaseUserEntity`, `CommonJpaAutoConfiguration` 이동
- GitHub Packages `0.0.1-SNAPSHOT` 배포


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #1


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
- `com.firstticket.common.persistence` 패키지 경로 유지 -> 각 서비스 import 수정 불필요
- `common-jpa` 배포 완료 후 `common 0.0.3-SNAPSHOT`에서 JPA 관련 코드 및 의존성 제거 예정
- `common-jpa` 의존성 추가가 필요한 서비스는 README 참고


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * common-jpa 모듈 설명서 추가 및 사용/설정 예시 제공

* **New Features**
  * 엔터티 감사: 생성/수정 시간 자동 기록
  * 소프트 삭제 지원(삭제 시 타임스탬프 설정)
  * 사용자 추적: 생성자/수정자/삭제자 UUID 자동 기록
  * JPA 통합 자동설정 및 QueryDSL 연동(쿼리 팩토리 주입 예시 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->